### PR TITLE
Fix so jqueryEnv can be set to external

### DIFF
--- a/src/main/java/ca/canada/ised/wet/cdts/components/wet/config/beans/WETTemplate.java
+++ b/src/main/java/ca/canada/ised/wet/cdts/components/wet/config/beans/WETTemplate.java
@@ -18,7 +18,7 @@ public class WETTemplate {
 
     private String subtheme;
 
-    private Boolean loadjqueryfromgoogle;
+    private String loadjqueryfromgoogle;
 
     private Boolean usehttps;
 
@@ -74,7 +74,7 @@ public class WETTemplate {
     /**
      * @param loadjqueryfromgoogle the loadjqueryfromgoogle to set
      */
-    public void setLoadjqueryfromgoogle(Boolean loadjqueryfromgoogle) {
+    public void setLoadjqueryfromgoogle(String loadjqueryfromgoogle) {
         this.loadjqueryfromgoogle = loadjqueryfromgoogle;
     }
 


### PR DESCRIPTION
OPTIONAL - jqueryEnv – Use this variable to specify which environment you want to pull the jQuery files from. By default they are loaded locally from the WET build. Otherwise use the following to load from Google CDN:
"jqueryEnv": external
reference https://cenw-wscoe.github.io/sgdc-cdts/docs/internet-en.html#CDTS_page_template